### PR TITLE
Remove unused count in ssh-key module

### DIFF
--- a/modules/log-analytics-workspace/main.tf
+++ b/modules/log-analytics-workspace/main.tf
@@ -1,7 +1,8 @@
 resource "azurerm_log_analytics_workspace" "main" {
   name                = "${var.prefix}-log-analytics-workspace"
-  location            = "${var.location}"
-  resource_group_name = "${var.resource_group_name}"
-  sku                 = "${var.sku}"
-  retention_in_days   = "${var.retention_in_days}"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  sku                 = var.sku
+  retention_in_days   = var.retention_in_days
 }
+

--- a/modules/log-analytics-workspace/outputs.tf
+++ b/modules/log-analytics-workspace/outputs.tf
@@ -1,7 +1,8 @@
 output "id" {
-  value = "${azurerm_log_analytics_workspace.main.id}"
+  value = azurerm_log_analytics_workspace.main.id
 }
 
 output "name" {
-  value = "${azurerm_log_analytics_workspace.main.name}"
+  value = azurerm_log_analytics_workspace.main.name
 }
+

--- a/modules/log-analytics-workspace/variables.tf
+++ b/modules/log-analytics-workspace/variables.tf
@@ -29,3 +29,4 @@ variable "log_retention_in_days" {
   description = "The retention period for the logs in days"
   default     = 30
 }
+

--- a/modules/log-analytics-workspace/versions.tf
+++ b/modules/log-analytics-workspace/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/modules/ssh-key/main.tf
+++ b/modules/ssh-key/main.tf
@@ -4,7 +4,6 @@ resource "tls_private_key" "ssh" {
 }
 
 resource "local_file" "private_key" {
-  count    = "${var.public_ssh_key == "" ? 1 : 0}"
   content  = tls_private_key.ssh.private_key_pem
   filename = "./private_ssh_key"
 }

--- a/modules/ssh-key/main.tf
+++ b/modules/ssh-key/main.tf
@@ -5,16 +5,17 @@ resource "tls_private_key" "ssh" {
 
 resource "local_file" "private_key" {
   count    = "${var.public_ssh_key == "" ? 1 : 0}"
-  content  = "${tls_private_key.ssh.private_key_pem}"
+  content  = tls_private_key.ssh.private_key_pem
   filename = "./private_ssh_key"
 }
 
 output "public_ssh_key" {
   # Only output a generated ssh public key
-  value = "${var.public_ssh_key != "" ? "" : tls_private_key.ssh.public_key_openssh}"
+  value = var.public_ssh_key != "" ? "" : tls_private_key.ssh.public_key_openssh
 }
 
 variable "public_ssh_key" {
   description = "An ssh key set in the main variables of the terraform-azurerm-aks module"
   default     = ""
 }
+

--- a/modules/ssh-key/versions.tf
+++ b/modules/ssh-key/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Remove unused count in ssh-key module

Causes troubles if ssh keys have not been created yet (terraform plan)
```
Error: Invalid count argument

  on modules/terraform-azurerm-aks/modules/ssh-key/main.tf line 7, in resource "local_file" "private_key":
   7:   count    = "${var.public_ssh_key == "" ? 1 : 0}"
```